### PR TITLE
Replace deprecated `performance.timing.navigationStart` with `performance.now()`

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -22,9 +22,19 @@ utils.nonce = ''; // Nonce value to allow for CSP whitelisting
 
 // Properties and function related to calculating Branch request roundtrip time
 utils.instrumentation = {};
-utils.navigationTimingAPIEnabled = typeof window !== 'undefined' && !!(window.performance && window.performance.timing && window.performance.timing.navigationStart);
+utils.navigationTimingAPIEnabled = typeof window !== 'undefined' &&
+	!!(window.performance &&
+	(typeof window.performance.now === 'function' ||
+	(window.performance.timing && window.performance.timing.navigationStart)));
 utils.timeSinceNavigationStart = function() {
 	// in milliseconds
+	// performance.now() returns the time elapsed since the time origin
+	// (navigation start), replacing the deprecated Navigation Timing Level 1
+	// API (performance.timing.navigationStart), which is kept as a fallback
+	// for older connected-device browsers.
+	if (typeof window.performance.now === 'function') {
+		return Math.round(window.performance.now()).toString();
+	}
 	return (Date.now() - window.performance.timing.navigationStart).toString();
 };
 utils.currentRequestBrttTag = "";


### PR DESCRIPTION
## Summary

`utils.timeSinceNavigationStart()` in `src/1_utils.js` currently relies on `window.performance.timing.navigationStart`, part of the Navigation Timing Level 1 API, which is deprecated and being phased out of Chromium. This PR switches the primary code path to `performance.now()`, which by definition returns the elapsed milliseconds since the time origin (navigation start).

The legacy `performance.timing.navigationStart` calculation is retained as a fallback for older connected-device browsers, so no environment loses the instrumentation.

## Why

- **Deprecation:** `performance.timing` is deprecated in favor of  `performance.timeOrigin` / `performance.now()`, and browsers have begun  removing Level 1 API surface. Connected/TV browsers based on recent Chromium builds will eventually stop exposing it.
- **Accuracy:** the old expression `Date.now() - navigationStart` mixes the wall clock with a fixed navigation timestamp, so the measurement drifts if the system clock adjusts mid-session (NTP sync, DST, user changes the
  time), a realistic scenario on TV devices that sync their clocks on wake. `performance.now()` is monotonic, so the `init-began-at` instrumentation becomes drift-free.

## Testing

- Verified the logic manually in three simulated environments:
  1. modern (only `performance.now`) → enabled, returns rounded ms string
  2. legacy (only `performance.timing.navigationStart`) → enabled, falls
     back to the original calculation
  3. no `performance` object → disabled, function never called
- `jshint` (`.jshintrc`) reports an identical warning count on
  `src/1_utils.js` before and after this change — no new lint issues.

Cheers,
Michael