### PR TITLE
[other] NO-TICKET: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BranchMetrics/disco-dna
+* @BranchMetrics/engmt-eng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BranchMetrics/engmt-eng
+* @BranchMetrics/sdk-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BranchMetrics/disco-dna


### PR DESCRIPTION
Assigns ownership via CODEOWNERS (* @BranchMetrics/disco-dna) as part of the service-catalogue rollout.